### PR TITLE
Update 04-hardware.adoc

### DIFF
--- a/chapters/04-hardware.adoc
+++ b/chapters/04-hardware.adoc
@@ -79,7 +79,7 @@ Hay varios tipos de instrucciones que implementan registros _RMW_, las disponibl
 - _compare&swap_: Compara el valor del registro con otro, si son iguales asigna uno nuevo y retorna el anterior.
 
 
-Los fabricantes implementan conjuntos de operaciones diferentes: para facilitar la programación y portabilidad los compiladores proveen macros, o _intrinsics_, más abstractos. Estos macros generan la secuencia de instrucciones nativas para cada arquitecturafootnote:[Por ejemplo GCC <<Atomics, tenía los macros>> `__sync_*`, en las últimas versiones fueron reemplazados por <<Atomics_C11, nuevos macros>> más cercanos al modelo de memoria de C11 y C++11.], los programadores no se deben preocupar de programar en ensamblador para cada arquitecturafootnote:[En el núcleo Linux no usan macros, lo haría dependiente del compilador y tampoco generan el código más eficiente. Se programa en ensamblador _empotrado_ para cada arquitectura.].
+Los fabricantes implementan conjuntos de operaciones diferentes; para facilitar la programación y portabilidad los compiladores proveen macros, o _intrinsics_, más abstractos. Estos macros generan la secuencia de instrucciones nativas para cada arquitecturafootnote:[Por ejemplo GCC <<Atomics, tenía los macros>> `__sync_*`, en las últimas versiones fueron reemplazados por <<Atomics_C11, nuevos macros>> más cercanos al modelo de memoria de C11 y C++11.], los programadores no se deben preocupar de programar en ensamblador para cada arquitecturafootnote:[En el núcleo Linux no usan macros, lo haría dependiente del compilador y tampoco generan el código más eficiente. Se programa en ensamblador _empotrado_ para cada arquitectura.].
 
 
 === Exclusión mutua con registros _Read-Modify-Write_
@@ -254,7 +254,7 @@ _CAS_ tiene un defecto conocido y estudiado, el _problema ABA_. Aunque no se pre
 - _Q_ modifica el registro con el valor _B_ y vuelve a poner el mismo valor _A_ antes que  _P_ vuelva a ejecutarse (de allí el nombre _ABA_).
 - _P_ ejecutará la instrucción _CAS_ sin haber detectado el cambio.
 
-Si _A_ y _B_ son valores simples no hay conflictos, pero si son punteros a estructuras más complejas, como nodos de una pila, un campo de esas estructuras pudo haber cambiado y provocar errores.
+Si _A_ y _B_ son valores simples no hay conflictos. Pero si son punteros a estructuras más complejas, como nodos de una pila, un campo de esas estructuras pudo haber cambiado y provocar errores.
 
 [[free_lock_stack]]
 ====== Pilas concurrentes sin bloqueo


### PR DESCRIPTION
No lo corrijo pero lo pongo aquí para que lo veas: 

"Aún en el núcleo del sistema operativo presenta dificultades, existe el riesgo de perder interrupciones y la complicación de deshabilitarlas en todos los procesadores."

Falta sujeto: ¿quién presenta dificultades? Opciones: 

"Aún en el núcleo del sistema operativo se presentan dificultades, existe el riesgo de perder interrupciones y la complicación de deshabilitarlas en todos los procesadores."

"Aún en el núcleo del sistema operativo, el proceso presenta dificultades: existe el riesgo de perder interrupciones y la complicación de deshabilitarlas en todos los procesadores."  -- si fuera el proceso, y si las dificultades fueran esas que se enumeran después de los dos puntos.
