### PR TITLE
Revisión del capítulo 5

### DIFF
--- a/chapters/05-spinlocks.adoc
+++ b/chapters/05-spinlocks.adoc
@@ -48,7 +48,7 @@ En cada iteración (o _spin_) los procesos en diferentes procesadores verifican 
 El objetivo de los _spinlocks_ escalables es minimizar el sobrecoste inducido por los _fallos_. La estrategia es que la espera activa de cada proceso se haga sobre posiciones de memoria diferentes.
 ****
 
-Veremos tres técnicas de optimización de _spinlocks_ que se pueden aplicar a cualquier proceso que itere sobre una variable compartida. Comprobaremos que sus mejoras en eficiencia son considerables.
+Veremos tres técnicas de optimización de _spinlocks_ que se pueden aplicar a cualquier espera activa sobre una variable compartida. Comprobaremos que sus mejoras en eficiencia son considerables.
 
 ==== Verificación local
 Se trata de reducir la presión sobre el sistema de coherencia de caché y reducir las llamadas a las relativamente costosas primitivas de sincronización. Antes de ejecutarlas se verifica (o _cortocircuita_) el valor del registro –+mutex+ en los ejemplos–; si vale 1 ya no hace falta continuar con la instrucción atómica. Cuando se usa con _TAS_ esta estrategia es conocida como _TTAS_ o _TATAS_; con _CAS_ se llama _TCAS_.


### PR DESCRIPTION
En el primer párrafo del apartado 'Ceder el procesador': 

_En un sistema con un único procesador es aún peor, se seguirá consumiendo CPU hasta que finalice el cuanto y no se dejará avanzar a otro proceso._

Supongo que "el cuanto" es un error, pero no se me ocurre qué palabra querías poner ahí, así que no he cambiado nada.
